### PR TITLE
add error handling for when there is nothing

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -4,4 +4,5 @@ import "errors"
 
 var (
 	ErrEncKeyNotFound = errors.New("encryption key not found")
+	ErrIssuerNotFound = errors.New("issuer not found")
 )


### PR DESCRIPTION
when vault trys to access an element that is not availabe yet, vault returns an error. vault should return nil because no element is found.  