### PR TITLE
change token type ttl to string

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -25,7 +25,7 @@ type AuthCreateTokenRequest struct {
 	NoParent        bool                   `json:"no_parent,omitempty"`
 	NoDefaultPolicy bool                   `json:"no_default_policy,omitempty"`
 	Renewable       bool                   `json:"renewable,omitempty"`
-	TTL             int                    `json:"ttl,omitempty"`
+	TTL             string                 `json:"ttl,omitempty"`
 	Type            string                 `json:"type,omitempty"`
 	EntityAlias     string                 `json:"entity_alias,omitempty"`
 }


### PR DESCRIPTION
https://developer.hashicorp.com/vault/api-docs/auth/token#create-token
ttl should be string not int

> [ttl](https://developer.hashicorp.com/vault/api-docs/auth/token#ttl) (string: "") - The TTL period of the token, provided as "1h", where hour is the largest suffix. If not provided, the token is valid for the [default lease TTL](https://developer.hashicorp.com/vault/docs/configuration), or indefinitely if the root policy is used.